### PR TITLE
feat: include yaml files in generated folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 node_modules/
-generated/
+generated/*
+!generated/*.yaml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package uses [openzeppelin-subgraphs](https://github.com/mento-protocol/ope
 
 For the Alfajores subgraph, use our shared test wallet from LastPass to log in to <https://thegraph.com/studio/subgraph/mento-alfajores/>
 
-For Mainnet, we will deploy a Gnosis Safe when the time comes.
+For Mainnet, we will deploy a Gnosis Safe. Until then we will use the shared test wallet from LastPass.
 
 ## Commands
 

--- a/generated/mento.mainnet.subgraph.yaml
+++ b/generated/mento.mainnet.subgraph.yaml
@@ -1,0 +1,132 @@
+specVersion: 0.0.4
+schema:
+  file: mento.mainnet.schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: voting
+    network: celo
+    source:
+      address: "0x001Bb66636dCd149A1A2bA8C50E408BdDd80279C"
+      abi: Voting
+      startBlock: 25901546
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Voting
+      abis:
+        - name: Voting
+          file: ../node_modules/@openzeppelin/contracts/build/contracts/IVotes.json
+      eventHandlers:
+        - event: DelegateChanged(indexed address,indexed address,indexed address)
+          handler: handleDelegateChanged
+        - event: DelegateVotesChanged(indexed address,uint256,uint256)
+          handler: handleDelegateVotesChanged
+      file: ../node_modules/@openzeppelin/subgraphs/src/datasources/voting.ts
+  - kind: ethereum/contract
+    name: locking
+    network: celo
+    source:
+      address: "0x001Bb66636dCd149A1A2bA8C50E408BdDd80279C"
+      abi: Locking
+      startBlock: 25901546
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Locking
+      abis:
+        - name: Locking
+          file: ..//contracts/ILocking.json
+      eventHandlers:
+        - event: LockCreate(indexed uint256,indexed address,indexed address,uint256,uint256,uint256,uint256)
+          handler: handleLockCreate
+        - event: Relock(indexed uint256,indexed address,indexed address,uint256,uint256,uint256,uint256,uint256)
+          handler: handleRelock
+        - event: Delegate(indexed uint256,indexed address,indexed address,uint256)
+          handler: handleDelegate
+        - event: Withdraw(indexed address,uint256)
+          handler: handleWithdraw
+      file: ../src/datasources/locking.ts
+  - kind: ethereum/contract
+    name: timelock
+    network: celo
+    source:
+      address: "0x890DB8A597940165901372Dd7DB61C9f246e2147"
+      abi: Timelock
+      startBlock: 25901546
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Timelock
+      abis:
+        - name: Timelock
+          file: ../node_modules/@openzeppelin/contracts/build/contracts/TimelockController.json
+      eventHandlers:
+        - event: CallScheduled(indexed bytes32,indexed uint256,address,uint256,bytes,bytes32,uint256)
+          handler: handleCallScheduled
+        - event: CallExecuted(indexed bytes32,indexed uint256,address,uint256,bytes)
+          handler: handleCallExecuted
+        - event: Cancelled(indexed bytes32)
+          handler: handleCancelled
+        - event: MinDelayChange(uint256,uint256)
+          handler: handleMinDelayChange
+      file: ../node_modules/@openzeppelin/subgraphs/src/datasources/timelock.ts
+  - kind: ethereum/contract
+    name: accesscontrol
+    network: celo
+    source:
+      address: "0x890DB8A597940165901372Dd7DB61C9f246e2147"
+      abi: AccessControl
+      startBlock: 25901546
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - AccessControl
+      abis:
+        - name: AccessControl
+          file: ../node_modules/@openzeppelin/contracts/build/contracts/IAccessControl.json
+      eventHandlers:
+        - event: RoleAdminChanged(indexed bytes32,indexed bytes32,indexed bytes32)
+          handler: handleRoleAdminChanged
+        - event: RoleGranted(indexed bytes32,indexed address,indexed address)
+          handler: handleRoleGranted
+        - event: RoleRevoked(indexed bytes32,indexed address,indexed address)
+          handler: handleRoleRevoked
+      file: ../node_modules/@openzeppelin/subgraphs/src/datasources/accesscontrol.ts
+  - kind: ethereum/contract
+    name: governor
+    network: celo
+    source:
+      address: "0x47036d78bB3169b4F5560dD77BF93f4412A59852"
+      abi: Governor
+      startBlock: 25901546
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Governor
+      abis:
+        - name: Governor
+          file: ../node_modules/@openzeppelin/contracts/build/contracts/IGovernorTimelock.json
+      eventHandlers:
+        - event: ProposalCanceled(uint256)
+          handler: handleProposalCanceled
+        - event: ProposalCreated(uint256,address,address[],uint256[],string[],bytes[],uint256,uint256,string)
+          handler: handleProposalCreated
+        - event: ProposalExecuted(uint256)
+          handler: handleProposalExecuted
+        - event: ProposalQueued(uint256,uint256)
+          handler: handleProposalQueued
+        - event: VoteCast(indexed address,uint256,uint8,uint256,string)
+          handler: handleVoteCast
+        - event: VoteCastWithParams(indexed address,uint256,uint8,uint256,string,bytes)
+          handler: handleVoteCastWithParams
+      file: ../node_modules/@openzeppelin/subgraphs/src/datasources/governor.ts

--- a/generated/mento.testnet.subgraph.yaml
+++ b/generated/mento.testnet.subgraph.yaml
@@ -1,0 +1,132 @@
+specVersion: 0.0.4
+schema:
+  file: mento.testnet.schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: voting
+    network: celo-alfajores
+    source:
+      address: "0x537CaE97C588C6DA64A385817F3D3563DDCf0591"
+      abi: Voting
+      startBlock: 21963085
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Voting
+      abis:
+        - name: Voting
+          file: ../node_modules/@openzeppelin/contracts/build/contracts/IVotes.json
+      eventHandlers:
+        - event: DelegateChanged(indexed address,indexed address,indexed address)
+          handler: handleDelegateChanged
+        - event: DelegateVotesChanged(indexed address,uint256,uint256)
+          handler: handleDelegateVotesChanged
+      file: ../node_modules/@openzeppelin/subgraphs/src/datasources/voting.ts
+  - kind: ethereum/contract
+    name: locking
+    network: celo-alfajores
+    source:
+      address: "0x537CaE97C588C6DA64A385817F3D3563DDCf0591"
+      abi: Locking
+      startBlock: 21963085
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Locking
+      abis:
+        - name: Locking
+          file: ..//contracts/ILocking.json
+      eventHandlers:
+        - event: LockCreate(indexed uint256,indexed address,indexed address,uint256,uint256,uint256,uint256)
+          handler: handleLockCreate
+        - event: Relock(indexed uint256,indexed address,indexed address,uint256,uint256,uint256,uint256,uint256)
+          handler: handleRelock
+        - event: Delegate(indexed uint256,indexed address,indexed address,uint256)
+          handler: handleDelegate
+        - event: Withdraw(indexed address,uint256)
+          handler: handleWithdraw
+      file: ../src/datasources/locking.ts
+  - kind: ethereum/contract
+    name: timelock
+    network: celo-alfajores
+    source:
+      address: "0xa0Ad8DD40104556122c21dF50eD14bb1B53A3338"
+      abi: Timelock
+      startBlock: 21963085
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Timelock
+      abis:
+        - name: Timelock
+          file: ../node_modules/@openzeppelin/contracts/build/contracts/TimelockController.json
+      eventHandlers:
+        - event: CallScheduled(indexed bytes32,indexed uint256,address,uint256,bytes,bytes32,uint256)
+          handler: handleCallScheduled
+        - event: CallExecuted(indexed bytes32,indexed uint256,address,uint256,bytes)
+          handler: handleCallExecuted
+        - event: Cancelled(indexed bytes32)
+          handler: handleCancelled
+        - event: MinDelayChange(uint256,uint256)
+          handler: handleMinDelayChange
+      file: ../node_modules/@openzeppelin/subgraphs/src/datasources/timelock.ts
+  - kind: ethereum/contract
+    name: accesscontrol
+    network: celo-alfajores
+    source:
+      address: "0xa0Ad8DD40104556122c21dF50eD14bb1B53A3338"
+      abi: AccessControl
+      startBlock: 21963085
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - AccessControl
+      abis:
+        - name: AccessControl
+          file: ../node_modules/@openzeppelin/contracts/build/contracts/IAccessControl.json
+      eventHandlers:
+        - event: RoleAdminChanged(indexed bytes32,indexed bytes32,indexed bytes32)
+          handler: handleRoleAdminChanged
+        - event: RoleGranted(indexed bytes32,indexed address,indexed address)
+          handler: handleRoleGranted
+        - event: RoleRevoked(indexed bytes32,indexed address,indexed address)
+          handler: handleRoleRevoked
+      file: ../node_modules/@openzeppelin/subgraphs/src/datasources/accesscontrol.ts
+  - kind: ethereum/contract
+    name: governor
+    network: celo-alfajores
+    source:
+      address: "0x558e92236f85Bb4e8A63ec0D5Bf9d34087Eab744"
+      abi: Governor
+      startBlock: 21963085
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Governor
+      abis:
+        - name: Governor
+          file: ../node_modules/@openzeppelin/contracts/build/contracts/IGovernorTimelock.json
+      eventHandlers:
+        - event: ProposalCanceled(uint256)
+          handler: handleProposalCanceled
+        - event: ProposalCreated(uint256,address,address[],uint256[],string[],bytes[],uint256,uint256,string)
+          handler: handleProposalCreated
+        - event: ProposalExecuted(uint256)
+          handler: handleProposalExecuted
+        - event: ProposalQueued(uint256,uint256)
+          handler: handleProposalQueued
+        - event: VoteCast(indexed address,uint256,uint8,uint256,string)
+          handler: handleVoteCast
+        - event: VoteCastWithParams(indexed address,uint256,uint8,uint256,string,bytes)
+          handler: handleVoteCastWithParams
+      file: ../node_modules/@openzeppelin/subgraphs/src/datasources/governor.ts

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mainnet:codegen": "npx graph codegen ./generated/mento.mainnet.subgraph.yaml",
     "mainnet:build": "npx graph build ./generated/mento.mainnet.subgraph.yaml",
     "mainnet:build-all": "npm run clean && npm run mainnet:compile && npm run mainnet:codegen && npm run mainnet:build",
-    "mainnet:deploy": "npx graph deploy --studio mento ./generated/mento.mainnet.subgraph.yaml"
+    "mainnet:deploy": "npx graph deploy --studio mento-celo ./generated/mento.mainnet.subgraph.yaml"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
**Description**

This PR adds the subgraph YAML files for each network to make it easier to trace the contracts being indexed by the subgraph. The build generates these files, similar to the broadcast files we keep in the deployment repo. 