### PR TITLE
docs: point agents to master context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Mento Subgraph Instructions
+
+For any protocol-level question that crosses beyond this subgraph repo, first
+read the private `mento-master-context` router when the checkout is available:
+
+```text
+../mento-master-context/.agents/mento-context/README.md
+```
+
+This applies before broad repo searches for contracts, deployments, addresses,
+ABIs, live on-chain state, stable supply, reserve data, monitoring/data
+semantics, docs, the whitepaper, business model, or legal/risk framing. Load
+only the relevant master-context card(s), then return to this repo for subgraph
+implementation details.
+
+Indexed data can lag, omit historical ranges, or model derived state
+differently from contracts. Use this repo for subgraph mappings/schema, and
+verify current chain values with RPC at an explicit block. When answering,
+mention which master-context card you used or state that the checkout was
+unavailable.


### PR DESCRIPTION
## Summary
- Add a root AGENTS.md pointer to the private mento-master-context router.
- Keep this repo as source of truth for local implementation details while routing cross-protocol questions to the compact context index first.

## Validation
- git diff --check
- local autoreview helper: no deterministic findings
- commit/push hooks ran where configured

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, schema, or deployment impact.
> 
> **Overview**
> Adds root **`AGENTS.md`** so automated agents know how to work in this subgraph repo.
> 
> Agents are told to consult the private **`mento-master-context`** router (`../mento-master-context/.agents/mento-context/README.md`) **before** wide repo searches for contracts, deployments, ABIs, on-chain state, docs, and similar cross-protocol topics, then come back here for subgraph mappings and schema.
> 
> The file also notes that indexed subgraph data can lag or differ from contracts, and that live values should be checked via RPC at an explicit block, with attribution when master-context was used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0765a8b6550994b55ceb20e350c863a29f738d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->